### PR TITLE
fix repo url and homepage in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "flumecodec",
   "description": "",
   "version": "0.0.0",
-  "homepage": "https://github.com/dominictarr/flumecodec",
+  "homepage": "https://github.com/flumedb/flumecodec",
   "repository": {
     "type": "git",
-    "url": "git://github.com/dominictarr/flumecodec.git"
+    "url": "git://github.com/flumedb/flumecodec.git"
   },
   "dependencies": {
     "level-codec": "^6.2.0"


### PR DESCRIPTION
this keeps the npmjs.org page from redirecting to a github 404, since this repo was moved from dominictarr/flumecodec to the flumedb org